### PR TITLE
[fix] Cast Error

### DIFF
--- a/lib/src/expanded_grid.dart
+++ b/lib/src/expanded_grid.dart
@@ -15,10 +15,8 @@ class ExpandedGrid extends StatelessWidget {
         var contentHeight = boxConstraint.biggest.height / row;
 
         return Stack(
-            children: children.map((gridContent) {
-              if(gridContent.columnIndex < 0 || gridContent.columnIndex + gridContent.columnSpan - 1 >= column
-                  || gridContent.rowIndex < 0 || gridContent.rowIndex + gridContent.rowSpan - 1 >= row) return null;
-
+            children: children.where((e) => !(e.columnIndex < 0 || e.columnIndex + e.columnSpan - 1 >= column
+                || e.rowIndex < 0 || e.rowIndex + e.rowSpan - 1 >= row)).map((gridContent) {
               return Positioned(
                 top: contentHeight * gridContent.rowIndex,
                 left: contentWidth * gridContent.columnIndex,
@@ -28,7 +26,7 @@ class ExpandedGrid extends StatelessWidget {
                   child: gridContent,
                 ),
               );
-            }).where((element) => element != null).toList() as List<Widget>
+            }).toList() as List<Widget>
         );
       },
     );

--- a/lib/src/expanded_grid.dart
+++ b/lib/src/expanded_grid.dart
@@ -16,7 +16,7 @@ class ExpandedGrid extends StatelessWidget {
 
         return Stack(
             children: children.where((e) => !(e.columnIndex < 0 || e.columnIndex + e.columnSpan - 1 >= column
-                || e.rowIndex < 0 || e.rowIndex + e.rowSpan - 1 >= row)).map((gridContent) {
+                || e.rowIndex < 0 || e.rowIndex + e.rowSpan - 1 >= row)).map<Widget>((gridContent) {
               return Positioned(
                 top: contentHeight * gridContent.rowIndex,
                 left: contentWidth * gridContent.columnIndex,
@@ -26,7 +26,7 @@ class ExpandedGrid extends StatelessWidget {
                   child: gridContent,
                 ),
               );
-            }).toList() as List<Widget>
+            }).toList()
         );
       },
     );


### PR DESCRIPTION
```
======== Exception caught by widgets library =======================================================
The following _CastError was thrown building LayoutBuilder:
type 'List<Positioned?>' is not a subtype of type 'List<Widget>' in type cast

The relevant error-causing widget was: 
  LayoutBuilder LayoutBuilder:file:///C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/expanded_grid-1.0.0-nullsafety.0/lib/src/expanded_grid.dart:12:12
When the exception was thrown, this was the stack: 
#0      ExpandedGrid.build.<anonymous closure> (package:expanded_grid/src/expanded_grid.dart:31:61)
#1      _LayoutBuilderElement._layout.layoutCallback (package:flutter/src/widgets/layout_builder.dart:122:31)
#2      BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2531:19)
#3      _LayoutBuilderElement._layout (package:flutter/src/widgets/layout_builder.dart:154:12)
#4      RenderObject.invokeLayoutCallback.<anonymous closure> (package:flutter/src/rendering/object.dart:1962:59)
#5      PipelineOwner._enableMutationsToDirtySubtrees (package:flutter/src/rendering/object.dart:910:15)
#6      RenderObject.invokeLayoutCallback (package:flutter/src/rendering/object.dart:1962:14)
#7      RenderConstrainedLayoutBuilder.rebuildIfNecessary (package:flutter/src/widgets/layout_builder.dart:228:7)
```